### PR TITLE
Fix: Improve E2E test stability and CI workflow

### DIFF
--- a/frankies-blog/.github/workflows/ci.yml
+++ b/frankies-blog/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
       working-directory: ./frankies-blog
       run: pnpm analyze
       
+    - name: Install Playwright Browsers
+      working-directory: ./frankies-blog
+      run: pnpm exec playwright install --with-deps
+
     - name: Run e2e tests
       uses: microsoft/playwright-github-action@v1
       with:

--- a/frankies-blog/e2e/blog.spec.ts
+++ b/frankies-blog/e2e/blog.spec.ts
@@ -28,6 +28,7 @@ test.describe('Blog Page', () => {
     await page.goto('/blog');
     
     // Click on first blog post and wait for navigation
+    await page.locator('article').first().waitFor();
     const firstPost = page.locator('article').first();
     const postLink = firstPost.getByRole('link').first();
     await Promise.all([

--- a/frankies-blog/e2e/homepage.spec.ts
+++ b/frankies-blog/e2e/homepage.spec.ts
@@ -36,8 +36,11 @@ test.describe('Homepage', () => {
     // Check that main content is visible on mobile
     await expect(page.getByRole('main')).toBeVisible();
     
+    // Check that mobile menu button is visible
+    await expect(page.getByLabel('Open Menu')).toBeVisible();
+
     // Check that navigation works on mobile
-    await expect(page.getByRole('navigation')).toBeVisible();
+    // await expect(page.getByRole('navigation')).toBeVisible(); // Main navigation is hidden on mobile
   });
 
   test('has proper SEO elements', async ({ page }) => {


### PR DESCRIPTION
This commit addresses several issues to ensure a green CI build:

1.  **Mobile Homepage Navigation Test:**
    *   Modified `e2e/homepage.spec.ts` for the 'is responsive on mobile' test.
    *   Instead of checking for `getByRole('navigation')` (which is hidden on mobile), the test now asserts the visibility of the mobile menu button (`aria-label="Open Menu"`).

2.  **Blog Navigation Flake:**
    *   Updated `e2e/blog.spec.ts` in the 'can navigate to individual blog post' test.
    *   Added `await page.locator('article').first().waitFor();` to ensure the first article is rendered and interactive before attempting to click its link, preventing click interruption issues.

3.  **CI Workflow - Playwright Browsers:**
    *   Modified `.github/workflows/ci.yml` to include a new step: `pnpm exec playwright install --with-deps`.
    *   This step runs before 'Run e2e tests' to ensure all necessary Playwright browsers (including Mobile Safari) are installed in the CI environment.

4.  **E2E Test Audit:**
    *   Audited E2E tests for `toHaveCount.greaterThanOrEqual`.
    *   Confirmed that existing tests already use the preferred `expect(count).toBeGreaterThanOrEqual(...)` syntax, so no changes were needed for this point.

These changes aim to resolve the failing E2E tests and ensure the CI pipeline runs successfully.